### PR TITLE
Update entrypoint.sh

### DIFF
--- a/java/entrypoint.sh
+++ b/java/entrypoint.sh
@@ -4,6 +4,12 @@ cd /home/container
 
 export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
 
+[ ! -f server.properties ] && cat > server.properties << EOF
+server-ip=0.0.0.0
+server-port=${SERVER_PORT}
+query.port=${SERVER_PORT}
+EOF
+
 export MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 python3 /prompt.py --mode=echo
 export MODIFIED_STARTUP=`echo $(python3 /prompt.py --mode=env)`


### PR DESCRIPTION
Premake server.properties file with the server ip and port since first boot can stop players connecting after installing mods. Minecraft will populate the rest of this file with the values it needs for whatever version is running.